### PR TITLE
fix: fixing audio error for content type

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -857,6 +857,7 @@ export class SenderLayer extends AutomateLayer {
         let base64: string | false = await downloadFileToBase64(filePath, [
           'audio/mpeg',
           'audio/mp3',
+          'audio/aac',
         ])
 
         if (!base64) {
@@ -877,7 +878,8 @@ export class SenderLayer extends AutomateLayer {
         if (
           !mimeInfo ||
           mimeInfo.includes('audio/mpeg') ||
-          mimeInfo.includes('audio/mp3')
+          mimeInfo.includes('audio/mp3') ||
+          mimeInfo.includes('audio/aac')
         ) {
           const result: any = await this.page.evaluate(
             ({ to, base64, passId, checkNumber, forcingReturn, delSend }) => {


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request

- Fixed non accepted content error when sending audio with type audio/aac


To test (it takes a while): `npm install github:<username>/venom#<branch>`
