### PR TITLE
ci: remove semantic-release/github from releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@ dryRun: false
 plugins:
   - '@semantic-release/commit-analyzer'
   - '@semantic-release/release-notes-generator'
-  - '@semantic-release/github'
+  # - '@semantic-release/github'
   - '@semantic-release/npm'
   - - '@semantic-release/git'
     - assets: ['package.json']


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request

-
-

To test (it takes a while): `npm install github:<username>/venom#<branch>`
