### PR TITLE
Fix/fixing video webm error

### DIFF
--- a/src/api/helpers/download-file.ts
+++ b/src/api/helpers/download-file.ts
@@ -1,11 +1,13 @@
 import axios from 'axios'
+import { NotAllowedMimetype } from './not-allowed-mimetype.enum'
+import { logger } from '../../utils/logger'
 
 export async function downloadFileToBase64(
   _path: string,
   _mines: (string | RegExp)[] = []
 ): Promise<string | false> {
   if (!Array.isArray(_mines)) {
-    console.error(`set mines string array, not "${typeof _mines}" `)
+    logger.error(`set mines string array, not "${typeof _mines}" `)
     return false
   }
 
@@ -21,6 +23,12 @@ export async function downloadFileToBase64(
     })
 
     const mimeType = response.headers['content-type']
+
+    if (mimeType.includes(NotAllowedMimetype.videoWebm)) {
+      logger.error(`Content-Type "${mimeType}" of ${_path} is not allowed`)
+      return false
+    }
+    
     if (_mines.length) {
       const isValidMime = _mines.some((m) => {
         if (typeof m === 'string') {
@@ -29,7 +37,7 @@ export async function downloadFileToBase64(
         return m.exec(mimeType)
       })
       if (!isValidMime) {
-        console.error(`Content-Type "${mimeType}" of ${_path} is not allowed`)
+        logger.error(`Content-Type "${mimeType}" of ${_path} is not allowed`)
         return false
       }
     }

--- a/src/api/helpers/not-allowed-mimetype.enum.ts
+++ b/src/api/helpers/not-allowed-mimetype.enum.ts
@@ -1,0 +1,3 @@
+export enum NotAllowedMimetype {
+  videoWebm = 'video/webm',
+}

--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -1017,41 +1017,55 @@ export class SenderLayer extends AutomateLayer {
 
       filename = filenameFromMimeType(filename, mimeType)
 
-      const result = await this.page.evaluate(
-        ({
-          to,
-          base64,
-          filename,
-          caption,
-          passId,
-          checkNumber,
-          forcingReturn,
-          delSend,
-        }) => {
-          return WAPI.sendFile(
-            base64,
+      let result = {}
+      try {
+        result = await this.page.evaluate(
+          ({
             to,
+            base64,
             filename,
             caption,
-            'sendFile',
-            undefined,
             passId,
             checkNumber,
             forcingReturn,
-            delSend
-          )
-        },
-        {
-          to,
-          base64,
-          filename,
-          caption,
-          passId,
-          checkNumber,
-          forcingReturn,
-          delSend,
+            delSend,
+          }) => {
+            return WAPI.sendFile(
+              base64,
+              to,
+              filename,
+              caption,
+              'sendFile',
+              undefined,
+              passId,
+              checkNumber,
+              forcingReturn,
+              delSend
+            )
+          },
+          {
+            to,
+            base64,
+            filename,
+            caption,
+            passId,
+            checkNumber,
+            forcingReturn,
+            delSend,
+          }
+        )
+      } catch (error) {
+        result = {
+          erro: true,
+          to: to,
+          text: error.message,
         }
-      )
+
+        if (error.message.includes('protocolTimeout')) {
+          await this.page.reload()
+        }
+      }
+
       if (result['erro'] == true) {
         reject(result)
       } else {


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request

-  Added validation to not accept type video/webm
- Added try catch at sendFile to avoid browser closing due to time out error 

To test (it takes a while): `npm install github:<username>/venom#<branch>`
